### PR TITLE
Add configuration objects to repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Bazel
+/bazel-*
+/vendor/
+
 # Binaries for programs and plugins
 *.exe
 *.dll

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "gazelle")
+
+# TODO(diegs): remove '-proto disable' once
+# https://github.com/bazelbuild/rules_go/issues/859 is resolved.
+gazelle(
+    name = "gazelle",
+    args = [
+        "-proto",
+        "disable",
+    ],
+    command = "fix",
+    external = "vendored",
+    prefix = "github.com/coreos/tectonic-config",
+)
+
+# This target is the same as the one above, but prints diffs instead of fixing the files directly.
+# Used by the linter.
+gazelle(
+    name = "gazelle_diff",
+    args = [
+        "-proto",
+        "disable",
+        "-mode",
+        "diff",
+    ],
+    command = "fix",
+    external = "vendored",
+    prefix = "github.com/coreos/tectonic-config",
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Tectonic Operator Configuration
+
+This repository contains configuration objects used by the [Tectonic
+Installer](https://github.com/coreos/tectonic-installer) to configure the
+operators that install and update components in a Tectonic cluster.
+
+## Configuration Objects
+
+Configuration objects are defined for the following operators:
+
+* [Kube Addon Operator](config/kube-addon)
+* [Kube Core Operator](config/kube-core)
+* [Tectonic Networking Operator](config/tectonic-network)
+* [Tectonic Utility Operator](config/tectonic-utiltiy)
+
+In addition, some utility functions are defined in the [config
+library](config/).
+
+## Build/Test
+
+Build and test objects using Bazel. There are utilities tools
+in the [tools](tools/) directory for updating `BUILD` rules
+and vendoring.
+
+## Vendoring
+
+This repository uses glide for vendoring. Since this is a library the `vendor/`
+directory is not committed to the repository. To install the correct libraries
+to the `vendor/` directory for local development use `glide install`.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,15 @@
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "341d5eacef704415386974bc82a1783a8b7ffbff2ab6ba02375e1ca20d9b031c",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.7.1/rules_go-0.7.1.tar.gz",
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+
+proto_register_toolchains()

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["config.go"],
+    importpath = "github.com/coreos/tectonic-config/config",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/ghodss/yaml:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["config_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
+    importpath = "github.com/coreos/tectonic-config/config",
+    deps = [
+        "//config/kube-core:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+)
+
+// ToFile writes the configuration object to a file at path. Supported extensions are `json` and
+// `yaml`.
+func ToFile(path string, obj interface{}) error {
+	var data []byte
+	var err error
+	switch filepath.Ext(path) {
+	case ".yaml":
+		data, err = yaml.Marshal(obj)
+	case ".json":
+		data, err = json.Marshal(obj)
+	default:
+		err = fmt.Errorf("unrecognized config file format: %q", filepath.Ext(path))
+	}
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path, data, 0644)
+}
+
+// FromFile reads the configuration object from the file at path. Supported extensions are `json` and
+// `yaml`.
+func FromFile(path string, obj interface{}) error {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read config from %q: %v", path, err)
+	}
+
+	switch filepath.Ext(path) {
+	case ".yaml":
+		return yaml.Unmarshal(b, obj)
+	case ".json":
+		return json.Unmarshal(b, obj)
+	default:
+		return fmt.Errorf("unrecognized config file format: %q", filepath.Ext(path))
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubecore "github.com/coreos/tectonic-config/config/kube-core"
+)
+
+var config = &kubecore.OperatorConfig{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       kubecore.Kind,
+		APIVersion: kubecore.APIVersion,
+	},
+	AuthConfig: kubecore.AuthConfig{
+		OIDCClientID:      "tectonic-kubectl",
+		OIDCIssuerURL:     "https://kco-test.coreservices.team.coreos.systems/identity",
+		OIDCGroupsClaim:   "groups",
+		OIDCUsernameClaim: "email",
+	},
+	CloudProviderConfig: kubecore.CloudProviderConfig{
+		CloudConfigPath:      "/cloud/config/path",
+		CloudProviderProfile: "aws",
+	},
+	NetworkConfig: kubecore.NetworkConfig{
+		AdvertiseAddress: "0.0.0.0",
+		ClusterCIDR:      "10.2.0.0/16",
+		EtcdServers:      "https://kco-test-etcd-0.coreservices.team.coreos.systems:2379",
+		ServiceCIDR:      "10.3.0.0/16",
+	},
+	InitialConfig: kubecore.InitialConfig{
+		InitialMasterCount: 2,
+	},
+}
+
+func TestToFile(t *testing.T) {
+	got := &kubecore.OperatorConfig{}
+	err := FromFile("testdata/kco-config.yaml", got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(config, got) {
+		t.Fatalf("Expected unmarshaled config to look like:\n\n%#v\n\ngot:\n\n%#v", config, got)
+	}
+}
+func TestFromFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "config-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, "kco-config.yaml")
+
+	if err := ToFile(path, config); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want, err := ioutil.ReadFile("testdata/kco-config.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("Expected config to look like:\n\n%s\n\ngot:\n\n%s", want, got)
+	}
+}

--- a/config/kube-addon/BUILD.bazel
+++ b/config/kube-addon/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["config.go"],
+    importpath = "github.com/coreos/tectonic-config/config/kube-addon",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library"],
+)

--- a/config/kube-addon/config.go
+++ b/config/kube-addon/config.go
@@ -1,0 +1,29 @@
+package kubeaddon
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// Kind is the TypeMeta.Kind for the OperatorConfig.
+	Kind = "KubeAddonOperatorConfig"
+	// APIVersion is the TypeMeta.APIVersion for the OperatorConfig.
+	APIVersion = "v1"
+)
+
+// OperatorConfig contains configuration for KAO managed add-ons
+type OperatorConfig struct {
+	metav1.TypeMeta `json:",inline"`
+	HeapsterConfig  `json:"heapsterConfig,omitempty"`
+	DNSConfig       `json:"dnsConfig,omitempty"`
+	CloudProvider   string `json:"cloudProvider,omitempty"`
+}
+
+// HeapsterConfig options for heapster add on
+type HeapsterConfig struct{}
+
+// DNSConfig options for the dns configuration
+type DNSConfig struct {
+	// ClusterIP ip address of the cluster
+	ClusterIP string `json:"clusterIP"`
+}

--- a/config/kube-core/BUILD.bazel
+++ b/config/kube-core/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["config.go"],
+    importpath = "github.com/coreos/tectonic-config/config/kube-core",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library"],
+)

--- a/config/kube-core/config.go
+++ b/config/kube-core/config.go
@@ -1,0 +1,52 @@
+package kubecore
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// Kind is the TypeMeta.Kind for the OperatorConfig.
+	Kind = "KubeCoreOperatorConfig"
+	// APIVersion is the TypeMeta.APIVersion for the OperatorConfig.
+	APIVersion = "v1"
+)
+
+// OperatorConfig holds all configuration needed for the operator to make any install / upgrade time
+// decisions.
+type OperatorConfig struct {
+	metav1.TypeMeta     `json:",inline"`
+	AuthConfig          `json:"authConfig,omitempty"`
+	CloudProviderConfig `json:"cloudProviderConfig,omitempty"`
+	NetworkConfig       `json:"networkConfig,omitempty"`
+	InitialConfig       `json:"initialConfig,omitempty"`
+}
+
+// AuthConfig holds Authentication related config values.
+type AuthConfig struct {
+	OIDCClientID      string `json:"oidc_client_id"`
+	OIDCIssuerURL     string `json:"oidc_issuer_url"`
+	OIDCGroupsClaim   string `json:"oidc_groups_claim"`
+	OIDCUsernameClaim string `json:"oidc_username_claim"`
+}
+
+// CloudProviderConfig holds information on the cloud provider this cluster is operating in.
+type CloudProviderConfig struct {
+	CloudConfigPath      string `json:"cloud_config_path"`
+	CloudProviderProfile string `json:"cloud_provider_profile"`
+}
+
+// NetworkConfig holds information on cluster networking.
+type NetworkConfig struct {
+	AdvertiseAddress string `json:"advertise_address"`
+	ClusterCIDR      string `json:"cluster_cidr"`
+	EtcdServers      string `json:"etcd_servers"`
+	ServiceCIDR      string `json:"service_cidr"`
+}
+
+// InitialConfig holds information stored at cluster install time. This information may not always
+// be completely accurate throughout the lifecycle of the cluster as values may change over time.
+// These values should not be relied on across versions. These values should only be used during
+// installation and should not drive decisions during upgrades.
+type InitialConfig struct {
+	InitialMasterCount int `json:"initial_master_count"`
+}

--- a/config/tectonic-network/BUILD.bazel
+++ b/config/tectonic-network/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["config.go"],
+    importpath = "github.com/coreos/tectonic-config/config/tectonic-network",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library"],
+)

--- a/config/tectonic-network/config.go
+++ b/config/tectonic-network/config.go
@@ -1,0 +1,47 @@
+package tectonicnetwork
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// Kind is the TypeMeta.Kind for the OperatorConfig.
+	Kind = "TectonicNetworkOperatorConfig"
+	// APIVersion is the TypeMeta.APIVersion for the OperatorConfig.
+	APIVersion = "v1"
+)
+
+// NetworkType indicates the network configuration of the cluster.
+//
+// NOTE: only one of none, flannel, canal or calico can be enabled at a time.
+type NetworkType string
+
+const (
+	// NetworkNone is the network profile for a cluster that does not use the TNO to configure
+	// networking.
+	NetworkNone NetworkType = "none"
+	// NetworkFlannel is the network profile for a cluster that implements flannel.
+	NetworkFlannel NetworkType = "flannel"
+	// NetworkCanal is the network profile for a cluster that implements canal.
+	NetworkCanal = "canal"
+	// NetworkCalicoIPIP is the network profile for a cluster that implements calico.
+	NetworkCalicoIPIP = "calico-ipip"
+)
+
+// OperatorConfig defines the configuration needed by the Tectonic Network Operator.
+type OperatorConfig struct {
+	metav1.TypeMeta `json:",inline"`
+
+	// PodCIDR is an IP range from which pod IPs can be assigned.
+	PodCIDR string `json:"podCIDR"`
+	// NetworkProfile describes the network configuration for the cluster.
+	NetworkProfile NetworkType `json:"networkProfile"`
+	// CalicoConfig is used only when the networkType is `calico`.
+	CalicoConfig `json:"calicoConfig"`
+}
+
+// CalicoConfig defines config values when the network profile supports `calico`.
+type CalicoConfig struct {
+	// MTU sets the MTU size for workload interfaces and the IP-in-IP tunnel device.
+	MTU string `json:"mtu"`
+}

--- a/config/tectonic-utility/BUILD.bazel
+++ b/config/tectonic-utility/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["config.go"],
+    importpath = "github.com/coreos/tectonic-config/config/tectonic-utility",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library"],
+)

--- a/config/tectonic-utility/config.go
+++ b/config/tectonic-utility/config.go
@@ -1,0 +1,55 @@
+package tectonicutility
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// Kind is the TypeMeta.Kind for the OperatorConfig.
+	Kind = "TectonicUtilityOperatorConfig"
+	// APIVersion is the TypeMeta.APIVersion for the OperatorConfig.
+	APIVersion = "v1"
+)
+
+// OperatorConfig defines the config for Tectonic Utility Operator.
+type OperatorConfig struct {
+	metav1.TypeMeta         `json:",inline"`
+	IdentityConfig          `json:"identityConfig"`
+	IngressConfig           `json:"ingressConfig"`
+	StatsEmitterConfig      `json:"statsEmitterConfig"`
+	TectonicConfigMapConfig `json:"tectonicConfigMap"`
+}
+
+// IdentityConfig defines the config for Tectonic Identity.
+type IdentityConfig struct {
+	AdminEmail        string `json:"adminEmail"`
+	AdminPasswordHash string `json:"adminPasswordHash"`
+	AdminUserID       string `json:"adminUserID"`
+	ConsoleClientID   string `json:"consoleClientID"`
+	ConsoleSecret     string `json:"consoleSecret"`
+	KubectlClientID   string `json:"kubectlClientID"`
+	KubectlSecret     string `json:"kubectlSecret"`
+}
+
+// IngressConfig defines the config for Tectonic Ingress.
+type IngressConfig struct {
+	ConsoleBaseHost string `json:"consoleBaseHost"`
+	IngressKind     string `json:"ingressKind"`
+}
+
+// StatsEmitterConfig defines the config for Tectonic Stats Emitter.
+type StatsEmitterConfig struct {
+	StatsURL string `json:"statsURL"`
+}
+
+// TectonicConfigMapConfig defines the variables that will be used by the Tectonic ConfigMap.
+type TectonicConfigMapConfig struct {
+	BaseAddress          string `json:"baseAddress"`
+	CertificatesStrategy string `json:"certificatesStrategy"`
+	ClusterID            string `json:"clusterID"`
+	ClusterName          string `json:"clusterName"`
+	IdentityAPIService   string `json:"identityAPIService"`
+	InstallerPlatform    string `json:"installerPlatform"`
+	KubeAPIServerURL     string `json:"kubeAPIserverURL"`
+	TectonicVersion      string `json:"tectonicVersion"`
+}

--- a/config/testdata/kco-config.yaml
+++ b/config/testdata/kco-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+authConfig:
+  oidc_client_id: tectonic-kubectl
+  oidc_groups_claim: groups
+  oidc_issuer_url: https://kco-test.coreservices.team.coreos.systems/identity
+  oidc_username_claim: email
+cloudProviderConfig:
+  cloud_config_path: /cloud/config/path
+  cloud_provider_profile: aws
+initialConfig:
+  initial_master_count: 2
+kind: KubeCoreOperatorConfig
+networkConfig:
+  advertise_address: 0.0.0.0
+  cluster_cidr: 10.2.0.0/16
+  etcd_servers: https://kco-test-etcd-0.coreservices.team.coreos.systems:2379
+  service_cidr: 10.3.0.0/16

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,98 @@
+hash: ce124d2bc4b3aa5392ff499dcd14371c8cbf5c9027543d0d4a2d5ee1169d7fbf
+updated: 2018-01-16T13:27:06.169986719Z
+imports:
+- name: github.com/emicklei/go-restful
+  version: ff4f55a206334ef123e4f79bbf348980da81ca46
+  subpackages:
+  - log
+- name: github.com/ghodss/yaml
+  version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
+- name: github.com/go-openapi/jsonpointer
+  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
+- name: github.com/go-openapi/jsonreference
+  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
+- name: github.com/go-openapi/spec
+  version: 7abd5745472fff5eb3685386d5fb8bf38683154d
+- name: github.com/go-openapi/swag
+  version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
+- name: github.com/gogo/protobuf
+  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
+  subpackages:
+  - proto
+  - sortkeys
+- name: github.com/golang/glog
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- name: github.com/google/gofuzz
+  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
+- name: github.com/mailru/easyjson
+  version: 2f5df55504ebc322e4d52d34df6a1f5b503bf26d
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
+- name: github.com/PuerkitoBio/purell
+  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
+- name: github.com/PuerkitoBio/urlesc
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/spf13/pflag
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+- name: golang.org/x/net
+  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  subpackages:
+  - html
+  - html/atom
+  - http2
+  - http2/hpack
+  - idna
+  - lex/httplex
+  - websocket
+- name: golang.org/x/text
+  version: b19bf474d317b857955b12035d2c5acb57ce8b01
+  subpackages:
+  - cases
+  - internal
+  - internal/tag
+  - language
+  - runes
+  - secure/bidirule
+  - secure/precis
+  - transform
+  - unicode/bidi
+  - unicode/norm
+  - width
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
+- name: gopkg.in/yaml.v2
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+- name: k8s.io/api
+  version: af4bc157c3a209798fc897f6d4aaaaeb6c2e0d6a
+- name: k8s.io/apimachinery
+  version: 180eddb345a5be3a157cea1c624700ad5bd27b8f
+  subpackages:
+  - pkg/api/resource
+  - pkg/apis/meta/v1
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/fields
+  - pkg/labels
+  - pkg/runtime
+  - pkg/runtime/schema
+  - pkg/selection
+  - pkg/types
+  - pkg/util/errors
+  - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/net
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/wait
+  - pkg/watch
+  - third_party/forked/golang/reflect
+- name: k8s.io/kube-openapi
+  version: 39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1
+  subpackages:
+  - pkg/common
+  - pkg/util/proto
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,8 @@
+package: github.com/coreos/tectonic-config
+import:
+- package: k8s.io/api
+  version: kubernetes-1.9.0
+- package: k8s.io/apimachinery
+  version: kubernetes-1.9.0
+- package: github.com/ghodss/yaml
+  version: v1.0.0

--- a/tools/update-build.sh
+++ b/tools/update-build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# This script updates all BUILD.bazel rules for Go packages. It's just a thin
+# wrapper around gazelle.
+
+set -euo pipefail
+
+# Go to the root of the repo
+cd "$(git rev-parse --show-cdup)"
+
+bazel run //:gazelle

--- a/tools/update-vendor.sh
+++ b/tools/update-vendor.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# This script updates Go vendoring using glide and then fixes BUILD.bazel
+# rules.
+
+set -euo pipefail
+
+# Go to the root of the repo
+cd "$(git rev-parse --show-cdup)"
+
+# Run glide.
+glide up -v
+
+# Sometimes vendor BUILD files cause problems, so delete them for now.
+# Gazelle will re-create the ones we need.
+# e.g. https://github.com/kubernetes/kubernetes/issues/50975
+find vendor -name 'BUILD*' -delete
+
+# Re-run Gazelle.
+./tools/update-build.sh


### PR DESCRIPTION
This adds configuration objects for the following operators:
- Kube Addon
- Kube Core
- Tectonic Network
- Tectonic Utilty

It also adds the README and Bazel build/vendoring boilerplate.