### PR TITLE
kube-core: add global cluster config options

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,6 +18,9 @@ var config = &kubecore.OperatorConfig{
 		Kind:       kubecore.Kind,
 		APIVersion: kubecore.APIVersion,
 	},
+	ClusterConfig: kubecore.ClusterConfig{
+		APIServerURL: "https://kco-test-api.coreservices.team.coreos.systems",
+	},
 	AuthConfig: kubecore.AuthConfig{
 		OIDCClientID:      "tectonic-kubectl",
 		OIDCIssuerURL:     "https://kco-test.coreservices.team.coreos.systems/identity",

--- a/config/kube-core/config.go
+++ b/config/kube-core/config.go
@@ -15,6 +15,7 @@ const (
 // decisions.
 type OperatorConfig struct {
 	metav1.TypeMeta     `json:",inline"`
+	ClusterConfig       `json:"clusterConfig,omitempty"`
 	AuthConfig          `json:"authConfig,omitempty"`
 	CloudProviderConfig `json:"cloudProviderConfig,omitempty"`
 	NetworkConfig       `json:"networkConfig,omitempty"`
@@ -40,4 +41,9 @@ type NetworkConfig struct {
 	ClusterCIDR      string `json:"cluster_cidr"`
 	EtcdServers      string `json:"etcd_servers"`
 	ServiceCIDR      string `json:"service_cidr"`
+}
+
+// ClusterConfig holds global/general information about the cluster.
+type ClusterConfig struct {
+	APIServerURL string `json:"apiserver_url"`
 }

--- a/config/testdata/kco-config.yaml
+++ b/config/testdata/kco-config.yaml
@@ -7,6 +7,8 @@ authConfig:
 cloudProviderConfig:
   cloud_config_path: /cloud/config/path
   cloud_provider_profile: aws
+clusterConfig:
+  apiserver_url: https://kco-test-api.coreservices.team.coreos.systems
 kind: KubeCoreOperatorConfig
 networkConfig:
   advertise_address: 0.0.0.0


### PR DESCRIPTION
- cluster api server address

These will be useful for creating kubeconfig-in-cluster used by kube-proxy to reach apiserver during bootstrap. 
https://github.com/kubernetes-incubator/bootkube/pull/767