### PR TITLE
kube-core: remove initial_config.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,9 +34,6 @@ var config = &kubecore.OperatorConfig{
 		EtcdServers:      "https://kco-test-etcd-0.coreservices.team.coreos.systems:2379",
 		ServiceCIDR:      "10.3.0.0/16",
 	},
-	InitialConfig: kubecore.InitialConfig{
-		InitialMasterCount: 2,
-	},
 }
 
 func TestToFile(t *testing.T) {

--- a/config/kube-core/config.go
+++ b/config/kube-core/config.go
@@ -18,7 +18,6 @@ type OperatorConfig struct {
 	AuthConfig          `json:"authConfig,omitempty"`
 	CloudProviderConfig `json:"cloudProviderConfig,omitempty"`
 	NetworkConfig       `json:"networkConfig,omitempty"`
-	InitialConfig       `json:"initialConfig,omitempty"`
 }
 
 // AuthConfig holds Authentication related config values.
@@ -41,12 +40,4 @@ type NetworkConfig struct {
 	ClusterCIDR      string `json:"cluster_cidr"`
 	EtcdServers      string `json:"etcd_servers"`
 	ServiceCIDR      string `json:"service_cidr"`
-}
-
-// InitialConfig holds information stored at cluster install time. This information may not always
-// be completely accurate throughout the lifecycle of the cluster as values may change over time.
-// These values should not be relied on across versions. These values should only be used during
-// installation and should not drive decisions during upgrades.
-type InitialConfig struct {
-	InitialMasterCount int `json:"initial_master_count"`
 }

--- a/config/testdata/kco-config.yaml
+++ b/config/testdata/kco-config.yaml
@@ -7,8 +7,6 @@ authConfig:
 cloudProviderConfig:
   cloud_config_path: /cloud/config/path
   cloud_provider_profile: aws
-initialConfig:
-  initial_master_count: 2
 kind: KubeCoreOperatorConfig
 networkConfig:
   advertise_address: 0.0.0.0


### PR DESCRIPTION
I'm not sure what it was supposed to be used for, but it's unused.

cc @abhinavdahiya 