### PR TITLE
kao-config: remove heapster.

### DIFF
--- a/config/kube-addon/config.go
+++ b/config/kube-addon/config.go
@@ -14,13 +14,9 @@ const (
 // OperatorConfig contains configuration for KAO managed add-ons
 type OperatorConfig struct {
 	metav1.TypeMeta `json:",inline"`
-	HeapsterConfig  `json:"heapsterConfig,omitempty"`
 	DNSConfig       `json:"dnsConfig,omitempty"`
 	CloudProvider   string `json:"cloudProvider,omitempty"`
 }
-
-// HeapsterConfig options for heapster add on
-type HeapsterConfig struct{}
 
 // DNSConfig options for the dns configuration
 type DNSConfig struct {


### PR DESCRIPTION
Heapster was empty and it is no longer used since heapster is replaced
by metrics-server. Simply remove it.