### PR TITLE
kao: Move tnc config from tuo to kao.

### DIFF
--- a/config/kube-addon/BUILD.bazel
+++ b/config/kube-addon/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["config.go"],
     importpath = "github.com/coreos/tectonic-config/config/kube-addon",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library"],
+    deps = [
+        "//config/tectonic-node-controller:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
 )

--- a/config/kube-addon/config.go
+++ b/config/kube-addon/config.go
@@ -2,6 +2,8 @@ package kubeaddon
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tnc "github.com/coreos/tectonic-config/config/tectonic-node-controller"
 )
 
 const (
@@ -13,9 +15,10 @@ const (
 
 // OperatorConfig contains configuration for KAO managed add-ons
 type OperatorConfig struct {
-	metav1.TypeMeta `json:",inline"`
-	DNSConfig       `json:"dnsConfig,omitempty"`
-	CloudProvider   string `json:"cloudProvider,omitempty"`
+	metav1.TypeMeta      `json:",inline"`
+	DNSConfig            `json:"dnsConfig,omitempty"`
+	CloudProvider        string `json:"cloudProvider,omitempty"`
+	tnc.ControllerConfig `json:"tncConfig"`
 }
 
 // DNSConfig options for the dns configuration

--- a/config/tectonic-utility/BUILD.bazel
+++ b/config/tectonic-utility/BUILD.bazel
@@ -5,8 +5,5 @@ go_library(
     srcs = ["config.go"],
     importpath = "github.com/coreos/tectonic-config/config/tectonic-utility",
     visibility = ["//visibility:public"],
-    deps = [
-        "//config/tectonic-node-controller:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-    ],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library"],
 )

--- a/config/tectonic-utility/config.go
+++ b/config/tectonic-utility/config.go
@@ -2,8 +2,6 @@ package tectonicutility
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	tnc "github.com/coreos/tectonic-config/config/tectonic-node-controller"
 )
 
 const (
@@ -21,7 +19,6 @@ type OperatorConfig struct {
 	StatsEmitterConfig      `json:"statsEmitterConfig"`
 	TectonicConfigMapConfig `json:"tectonicConfigMap"`
 	NetworkConfig           `json:"networkConfig"`
-	tnc.ControllerConfig    `json:"tncConfig"`
 }
 
 // IdentityConfig defines the config for Tectonic Identity.


### PR DESCRIPTION
Because we want to keep tnc in the kube-system namespace, and we
want to the operator to manage a single namespace.