### PR TITLE
tectonic-node-controller: add platform

### DIFF
--- a/config/tectonic-node-controller/config.go
+++ b/config/tectonic-node-controller/config.go
@@ -20,9 +20,11 @@ const (
 type ControllerConfig struct {
 	metav1.TypeMeta     `json:",inline"`
 	ClusterDNSIP        string `json:"clusterDNSIP"`
-	CloudProvider       string `json:"cloudProvider"`
 	CloudProviderConfig string `json:"cloudProviderConfig"`
 	ClusterName         string `json:"clusterName"`
+
+	// The tectonic platform, e.g. "libvirt" or "aws"
+	Platform string `json:"platform"`
 
 	BaseDomain string `json:"baseDomain"`
 


### PR DESCRIPTION
Platform is distinct from cloud provider, so we need to be able to branch on both of these.